### PR TITLE
Update duti to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.1.2
+﻿# 1.1.3
+- Use latest duti version
+
+# 1.1.2
 - Add duti to the repo
 
 # 1.1.1

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "sails-async": "^1.0.0"
   },
   "devDependencies": {
-    "duti": "^0.3.2"
+    "duti": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-nested-blueprint",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Blueprints for nested waterline models for use in sails 1.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Makes duti use `latest` instead of pinning to a version.