### PR TITLE
Returning an object instead of using res.send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 1.3.1
+﻿# 1.3.2
+- Making sure count returns an object instead of using res.send
+  directly.
+
+ # 1.3.1
 - Add publish events for create/destroy.
 
 # 1.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-nested-blueprint",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Blueprints for nested waterline models for use in sails 1.0",
   "main": "index.js",
   "scripts": {

--- a/service.js
+++ b/service.js
@@ -36,7 +36,7 @@ module.exports = (models, modelName, req, res) => {
 
   let count = async record => {
     let model = models[modelName]
-    res.send(await model.count(record))
+    return {count: await model.count(record)}
   }
 
   return {


### PR DESCRIPTION
To fix `Error: Cannot write to response more than once`.