### PR TITLE
Cache and populations management on update, create, and destroy (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 1.4.4
+﻿# 1.5.0
+- Added nestedUpdate, using it for the cached update, and clearing
+  caches on the destroy methods.
+
+# 1.4.4
 - Fixed an issue with the cached update.
 
 # 1.4.3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library brings it back in a non-obstrusive way.
 
 ### Blueprint (Easiest)
 The blueprint will automatically figure out which model to use just like sails blueprints.
-`blueprint` exposes a `create`, a `destroy` and a `count`, so just do this in a controller method:
+`blueprint` exposes a `create`, a `destroy`, an `update` and a `count`, so just do this in a controller method:
 
 ```js
 let {blueprint} = require('sails-nested-blueprint')

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ extensible caching mechanism. The methods are `find` and `update`, and
 to be able to use them, you'll need to provide a `cache` object in the
 configuration options passed to
 `blueprintOptions`. The `cache` configuration object will have: a
-`provider` object containing a `get`, a `set` and a `del` functions,
+`provider` object containing a `get`, a `set`, a `del` and a `keys` functions,
 and a `prefix` alongsides the provider. See
 the following code as an example of how to use these methods on a
 Sails controller:
@@ -82,6 +82,9 @@ let blueprint = require('sails-nested-blueprint').blueprintOptions({
       },
       async del(keys) {
         await client.delAsync(keys)
+      },
+      async keys(query) {
+        await client.keys(query)
       }
     },
   },

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ let _ = require('lodash/fp')
 // Get the model identity from the action name (e.g. 'user/find').
 let getModelName = req => req.params.model || req.options.action.split('/')[0]
 let serviceFromReq = (req, res) => service(req._sails.models, getModelName(req), req, res)
-let create = async req => serviceFromReq(req).createNested(req.allParams())
-let update = async req => serviceFromReq(req).updateNested(req.allParams())
+let create = async req => serviceFromReq(req).createNested(null, req.allParams())
+let update = async req => serviceFromReq(req).updateNested(null, req.allParams())
 let cleanParams = req => _.omit('model', req.allParams())
 
 module.exports = {
@@ -22,16 +22,13 @@ module.exports = {
   }),
   blueprintOptions: (options = {}) => {
     let methods = {
-      create,
-      update,
-      cachedFind: async req => serviceFromReq(req).cachedFind(options.cache, cleanParams(req)),
-      clearCacheUpdate: async req => serviceFromReq(req).clearCacheUpdate(options.cache, cleanParams(req)),
+      create: async req => serviceFromReq(req).createNested(options.cache, req.allParams()),
+      update: async req => serviceFromReq(req).updateNested(options.cache, req.allParams()),
       destroy: async req => serviceFromReq(req).destroy(options.cache, options.destroy, cleanParams(req)),
       count: async (req, res) => serviceFromReq(req, res).count(cleanParams(req))
     }
     if (options.cache) {
       methods.find = async req => serviceFromReq(req).cachedFind(options.cache, cleanParams(req))
-      methods.update = async req => serviceFromReq(req).clearCacheUpdate(options.cache, cleanParams(req))
     }
     return controller(methods)
   }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ let _ = require('lodash/fp')
 let getModelName = req => req.params.model || req.options.action.split('/')[0]
 let serviceFromReq = (req, res) => service(req._sails.models, getModelName(req), req, res)
 let create = async req => serviceFromReq(req).createNested(req.allParams())
+let update = async req => serviceFromReq(req).updateNested(req.allParams())
 let cleanParams = req => _.omit('model', req.allParams())
 
 module.exports = {
@@ -15,15 +16,17 @@ module.exports = {
   serviceFromReq,
   blueprint: controller({
     create,
+    update,
     destroy: async req => serviceFromReq(req).destroyNested(cleanParams(req)),
     count: async (req, res) => serviceFromReq(req, res).count(cleanParams(req))
   }),
   blueprintOptions: (options = {}) => {
     let methods = {
       create,
+      update,
       cachedFind: async req => serviceFromReq(req).cachedFind(options.cache, cleanParams(req)),
       clearCacheUpdate: async req => serviceFromReq(req).clearCacheUpdate(options.cache, cleanParams(req)),
-      destroy: async req => serviceFromReq(req).destroy(options.destroy, cleanParams(req)),
+      destroy: async req => serviceFromReq(req).destroy(options.cache, options.destroy, cleanParams(req)),
       count: async (req, res) => serviceFromReq(req, res).count(cleanParams(req))
     }
     if (options.cache) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-nested-blueprint",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Blueprints for nested waterline models for use in sails 1.0",
   "main": "index.js",
   "scripts": {

--- a/service.js
+++ b/service.js
@@ -5,7 +5,7 @@ let publishCreate = (model, record, req) => model._publishCreate(record, req)
 let publishUpdate = (model, id, record, req) => model._publishUpdate(id, record, req)
 let hash = require('object-hash')
 
-let blacklist = ['limit', 'sort']
+let blacklist = ['limit', 'sort', 'skip']
 let memoryCache = {}
 let defaultCacheProvider = {
   get: key => _.get(key, memoryCache),

--- a/service.js
+++ b/service.js
@@ -31,52 +31,17 @@ let syncIDs = async (prefix, key, result, get, set) => {
 }
 
 module.exports = (models, modelName, req, res) => {
-  let cachedFind = _.curry(async (options, params) => {
-    let model = models[modelName]
-    let { get, set } = _.extend(defaultCacheProvider, options.provider)
-    let prefix = options.prefix
-    let queryObject = _.omit(blacklist, params)
-    if (queryObject.isDeleted) queryObject.isDeleted = false
-    let key = (options.keygen || keygen)(req, res, params, queryObject, modelName)
-    let cached
-    if (key) cached = await get(`${prefix}-${key}`)
-    if (key && cached) {
-      return cached
-    } else {
-      let build = model.find(queryObject)
-      _.each(blacklisted => {
-        if (params[blacklisted]) build = build[blacklisted](params[blacklisted])
-      }, blacklist)
-      _.each(({ alias }) => {
-        build = build.populate(alias)
-      }, model.associations)
-      let result = await build.then()
-      await syncIDs(prefix, `${prefix}-${key}`, result, get, set)
-      await set(`${prefix}-${key}`, result)
-      return result
-    }
-  })
-
-  let clearCacheUpdate = _.curry(async (options, params) => {
-    let model = models[modelName]
-    let { get, del } = _.extend(defaultCacheProvider, options.provider)
-    let prefix = options.prefix
-    let keys = await get(`${prefix}-keys`)
-    let id = params.id
-    let record = _.head(await model.find({id}).limit(1))
-    if (!_.isEmpty(record)) {
-      F.extendOn(record, _.omit('id', params))
-      await model.update({ id }, record)
-      if (_.get(params.id, keys)) await del(keys[params.id])
-      publishUpdate(model, params.id, params)
-    }
-    return record
-  })
-
-  let destroy = _.curry(async (options, record) => {
+  let destroy = _.curry(async (cacheOptions, options, record) => {
     let {soft = false, cascade = false, customDelete, beforeDelete} = options
     let model = models[modelName]
     let id = record.id
+
+    if (cacheOptions) {
+      let prefix = cacheOptions.prefix
+      let { get, del } = _.extend(defaultCacheProvider, cacheOptions.provider)
+      let keys = await get(`${prefix}-keys`)
+      if (_.get(id, keys)) await del(keys[id])
+    }
 
     if (_.isFunction(customDelete)) await customDelete(options, record, model, models)
     else {
@@ -107,6 +72,37 @@ module.exports = (models, modelName, req, res) => {
   let count = async record => {
     let model = models[modelName]
     return {count: await model.count(record)}
+  }
+
+  let updateNested = async record => {
+    let model = models[modelName]
+
+    let id = record.id
+    let originalRecord = await model.findOne({id}).then()
+    let updatedRecord = await model.update({id}, _.extend(originalRecord, _.mapValues(x => _.get('id', x) || x, record))).meta({ fetch: true }).then()
+    console.log({originalRecord, updatedRecord})
+
+    await Promise.all(_.map(async association => {
+      // Get Child Info
+      let childRecord = record[association.alias]
+      if (!childRecord || _.isString(childRecord)) return {}
+
+      let childModel = models[association[association.type]]
+      let childModelAssociation = _.find({collection: modelName}, childModel.associations) ||
+        _.find({model: modelName}, childModel.associations)
+
+      // Update child
+      childRecord[childModelAssociation.alias] = childModelAssociation.type === 'collection' ? [id] : id
+      let childId = childRecord.id
+      await childModel.update({ id: childId }, childRecord).then()
+
+      return {
+        [association.alias]: association.type === 'collection' ? [childId] : childId
+      }
+    }, model.associations))
+
+    publishUpdate(model, updatedRecord.id, record)
+    return _.extend({statusCode: 201}, updatedRecord)
   }
 
   let createNested = async record => {
@@ -147,14 +143,49 @@ module.exports = (models, modelName, req, res) => {
     return _.extend({statusCode: 201}, newRecord)
   }
 
+  let cachedFind = _.curry(async (options, params) => {
+    let model = models[modelName]
+    let { get, set } = _.extend(defaultCacheProvider, options.provider)
+    let prefix = options.prefix
+    let queryObject = _.omit(blacklist, params)
+    if (queryObject.isDeleted) queryObject.isDeleted = false
+    let key = (options.keygen || keygen)(req, res, params, queryObject, modelName)
+    let cached
+    if (key) cached = await get(`${prefix}-${key}`)
+    if (key && cached) {
+      return cached
+    } else {
+      let build = model.find(queryObject)
+      _.each(blacklisted => {
+        if (params[blacklisted]) build = build[blacklisted](params[blacklisted])
+      }, blacklist)
+      _.each(({ alias }) => {
+        build = build.populate(alias)
+      }, model.associations)
+      let result = await build.then()
+      await syncIDs(prefix, `${prefix}-${key}`, result, get, set)
+      await set(`${prefix}-${key}`, result)
+      return result
+    }
+  })
+
+  let clearCacheUpdate = _.curry(async (options, params) => {
+    let { get, del } = _.extend(defaultCacheProvider, options.provider)
+    let prefix = options.prefix
+    let keys = await get(`${prefix}-keys`)
+    if (_.get(params.id, keys)) await del(keys[params.id])
+    return updateNested(params)
+  })
+
   return {
-    cachedFind,
-    clearCacheUpdate,
     count,
     createNested,
+    updateNested,
     destroy,
-    destroyNested: destroy({cascade: true}),
-    destroyNestedSoft: destroy({soft: true, cascade: true}),
-    destroySoft: destroy({soft: true})
+    destroyNested: destroy(null, {cascade: true}),
+    destroyNestedSoft: destroy(null, {soft: true, cascade: true}),
+    destroySoft: destroy({soft: true}),
+    cachedFind,
+    clearCacheUpdate
   }
 }


### PR DESCRIPTION
v1.5.0

- New method `updatedNested` will handle clearing the cache for us.
- All the `destroy` methods now also clear the cache.
- Now we subscribe properly on `find` at both the record and the model level. We also send the publishCreate and publishUpdate with the `req` object, to avoid the emitters to receive their own events.
- `update` and `create` now answer with populated records.