### PR TITLE
Deleted users should have their emails changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.6.1
+# 1.7.0
+- Soft deletes will now update emails to end up with `-deleted` plus a number if a record already exists with `{email}-deleted{N-1}`.
+
+# 1.6.1
 - Return deleted record for destroy blueprint
 
 # 1.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-nested-blueprint",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Blueprints for nested waterline models for use in sails 1.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This feature will make `soft` deletes aware of email properties. We'll be updating emails to contain a `-deleted` sufix plus a number.
**Note:** I was thinking that maybe we could make this optional, or even make it just some kind of pipeline, but since we're the only users of this repo... 🤔